### PR TITLE
Add ADF service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# ADF Orchestration
+
+This project provides a small utility service to interact with Azure Data Factory (ADF).
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Define the following environment variables:
+   - `SUBSCRIPTION_ID`
+   - `RESOURCE_GROUP`
+   - `FACTORY_NAME`
+   - `AZURE_TENANT_ID`
+   - `AZURE_CLIENT_ID`
+   - `AZURE_CLIENT_SECRET`
+3. Use `ADFService` to trigger pipelines:
+   ```python
+   from adf_orchestration import ADFService
+
+   service = ADFService()
+   run_id = service.trigger_pipeline("my_pipeline", parameters={"foo": "bar"})
+   print(run_id)
+   ```
+
+## Testing
+
+Run tests with `pytest`:
+```bash
+pytest
+```

--- a/adf_orchestration/__init__.py
+++ b/adf_orchestration/__init__.py
@@ -1,0 +1,5 @@
+"""Azure Data Factory orchestration utilities."""
+
+from .service import ADFService
+
+__all__ = ["ADFService"]

--- a/adf_orchestration/service.py
+++ b/adf_orchestration/service.py
@@ -1,0 +1,45 @@
+import os
+from typing import Optional, Dict
+
+from azure.identity import ClientSecretCredential
+from azure.mgmt.datafactory import DataFactoryManagementClient
+
+
+class ADFService:
+    """Service for interacting with Azure Data Factory."""
+
+    def __init__(self) -> None:
+        self.subscription_id = os.environ["SUBSCRIPTION_ID"]
+        self.resource_group = os.environ["RESOURCE_GROUP"]
+        self.factory_name = os.environ["FACTORY_NAME"]
+
+        tenant_id = os.environ["AZURE_TENANT_ID"]
+        client_id = os.environ["AZURE_CLIENT_ID"]
+        client_secret = os.environ["AZURE_CLIENT_SECRET"]
+
+        credential = ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+        self.client = DataFactoryManagementClient(credential, self.subscription_id)
+
+    def trigger_pipeline(self, pipeline_name: str, parameters: Optional[Dict[str, str]] = None) -> str:
+        """Trigger an existing Azure Data Factory pipeline.
+
+        Args:
+            pipeline_name: Name of the pipeline to run.
+            parameters: Optional parameters to pass to the pipeline.
+
+        Returns:
+            The run ID of the triggered pipeline run.
+        """
+
+        run_response = self.client.pipelines.create_run(
+            resource_group_name=self.resource_group,
+            factory_name=self.factory_name,
+            pipeline_name=pipeline_name,
+            parameters=parameters or {},
+        )
+        return run_response.run_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 azure-mgmt-datafactory
+azure-identity
+pytest
+

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,95 @@
+import sys
+import os
+from types import SimpleNamespace, ModuleType
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+# Provide a lightweight stub for azure.identity so tests do not require the real
+# package which may not be installed in the execution environment.
+azure_identity_stub = ModuleType("azure.identity")
+
+class DummyCredential:
+    def __init__(self, *args, **kwargs):
+        pass
+
+azure_identity_stub.ClientSecretCredential = DummyCredential
+sys.modules.setdefault("azure.identity", azure_identity_stub)
+
+from adf_orchestration import ADFService
+
+
+class DummyPipelineRuns:
+    def create_run(self, resource_group_name, factory_name, pipeline_name, parameters):
+        self.called_with = {
+            "resource_group_name": resource_group_name,
+            "factory_name": factory_name,
+            "pipeline_name": pipeline_name,
+            "parameters": parameters,
+        }
+        return SimpleNamespace(run_id="dummy-run-id")
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.pipelines = DummyPipelineRuns()
+
+
+def test_service_initialization(monkeypatch):
+    env = {
+        "SUBSCRIPTION_ID": "sub",
+        "RESOURCE_GROUP": "rg",
+        "FACTORY_NAME": "factory",
+        "AZURE_TENANT_ID": "tenant",
+        "AZURE_CLIENT_ID": "client",
+        "AZURE_CLIENT_SECRET": "secret",
+    }
+    monkeypatch.setattr(os, "environ", env)
+
+    dummy_client = DummyClient()
+
+    def dummy_client_factory(credential, subscription_id):
+        assert subscription_id == "sub"
+        return dummy_client
+
+    monkeypatch.setattr(
+        "adf_orchestration.service.DataFactoryManagementClient", dummy_client_factory
+    )
+
+    service = ADFService()
+    assert service.client is dummy_client
+    assert service.resource_group == "rg"
+    assert service.factory_name == "factory"
+
+
+def test_trigger_pipeline(monkeypatch):
+    env = {
+        "SUBSCRIPTION_ID": "sub",
+        "RESOURCE_GROUP": "rg",
+        "FACTORY_NAME": "factory",
+        "AZURE_TENANT_ID": "tenant",
+        "AZURE_CLIENT_ID": "client",
+        "AZURE_CLIENT_SECRET": "secret",
+    }
+    monkeypatch.setattr(os, "environ", env)
+
+    dummy_client = DummyClient()
+
+    def dummy_client_factory(credential, subscription_id):
+        return dummy_client
+
+    monkeypatch.setattr(
+        "adf_orchestration.service.DataFactoryManagementClient", dummy_client_factory
+    )
+
+    service = ADFService()
+    run_id = service.trigger_pipeline("my-pipeline", parameters={"p1": "v1"})
+
+    assert run_id == "dummy-run-id"
+    assert dummy_client.pipelines.called_with == {
+        "resource_group_name": "rg",
+        "factory_name": "factory",
+        "pipeline_name": "my-pipeline",
+        "parameters": {"p1": "v1"},
+    }


### PR DESCRIPTION
## Summary
- add service to connect to Azure Data Factory using environment variables
- expose `ADFService` at package level
- add tests for the service with a stubbed Azure SDK
- document usage in `README`
- include dependencies in `requirements.txt`

## Testing
- `pytest -q`